### PR TITLE
Implement PDF export fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -720,7 +720,8 @@ document.getElementById('btnExportPdf').addEventListener('click', async function
     toast.textContent = 'PDF download gestart';
   }catch(err){
     console.error(err);
-    toast.textContent = 'Fout bij genereren PDF';
+    await printFallback();
+    return;
   }
   setTimeout(()=>toast.classList.add('hidden'), 4000);
 });


### PR DESCRIPTION
## Summary
- Handle PDF export errors by falling back to print

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aff1906e3c8330af360cec256b2dd3