### PR TITLE
Tweak cover and notes layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,9 +70,10 @@
 
     /* Ondertekenen blok */
     .sign-title{ margin-top:24px; margin-bottom:10px; font-size:10pt }
-    .sign-grid{ display:flex; gap:24px; align-items:flex-end }
+    .sign-grid{ display:flex; gap:24px; align-items:flex-start }
     .sign-grid > div{ flex:1 }
     .sign-left img{ height:100px; display:block; margin-bottom:8px }
+    .sign-right{ margin-top:108px }
     .sign-line{ border-top:2px solid #000; width:220px; margin-bottom:8px }
     .sign-text{ font-size:10pt; line-height:1.3 }
 
@@ -81,7 +82,7 @@
     .cover-photo{ position:absolute; inset:0; background-size:cover; background-position:center }
     .cover-overlay{ position:absolute; inset:0; background:url('https://www.acwbv.nl/wp-content/uploads/2025/08/Voorblad-template.png') center/cover no-repeat }
     /* Tekst exact in het rode vlak positioneren obv 1241x1756, x=45px, y=1120px (projectafspraak) */
-    .cover-text{ position:absolute; top:190mm; left:28mm; width:90mm; display:flex; justify-content:space-between; gap:1px; }
+    .cover-text{ position:absolute; top:197mm; left:28mm; width:90mm; display:flex; justify-content:space-between; gap:1px; }
     .cover-col{ width:48%; }
     .cover-col p{ margin:3px 0 }
     .cover-col .label{ font-weight:700 }
@@ -564,7 +565,17 @@
           }
         }
         const bp=await toDataUrl('https://www.acwbv.nl/wp-content/uploads/2025/08/Bulletpoint-ACW.png');
+        node.querySelectorAll('.acw-ul').forEach(ul=>{
+          ul.style.listStyle='none';
+          ul.style.paddingLeft='0';
+          ul.style.margin='8px 0 0';
+        });
         node.querySelectorAll('.acw-ul li').forEach(li=>{
+          li.style.listStyle='none';
+          li.style.position='relative';
+          li.style.paddingLeft='20px';
+          li.style.margin='6px 0';
+          li.style.fontSize='10pt';
           li.style.backgroundImage=`url('${bp}')`;
           li.style.backgroundRepeat='no-repeat';
           li.style.backgroundPosition='0 0.95em';
@@ -628,7 +639,7 @@
             .bg-img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover }
             .body{ position:relative; padding:28mm 22mm 24mm 22mm; font-size:10pt; line-height:1.5 }
             .cover-body{ position:relative; font-family:'Rajdhani', sans-serif; font-weight:500; color:#fff; }
-            .cover-text{ position:absolute; top:190mm; left:28mm; width:90mm; display:flex; justify-content:space-between; gap:1px; }
+            .cover-text{ position:absolute; top:197mm; left:28mm; width:90mm; display:flex; justify-content:space-between; gap:1px; }
             .cover-col{ width:48% }
             .cover-col p{ margin:3px 0 }
             .cover-col .label{ font-weight:700 }
@@ -642,6 +653,7 @@
             .acw-ul li::before{ content:'•'; position:absolute; left:0; top:0.2em; font-size:14px; color:#D52B1E; }
             .sign-title{ margin-top:24px; margin-bottom:10px; font-size:10pt }
             .sign-left img{ height:100px; display:block; margin-bottom:8px }
+            .sign-right{ margin-top:108px }
             .sign-line{ border-top:2px solid #000; width:220px; margin-bottom:8px }
             .sign-text{ font-size:10pt; line-height:1.3 }
           /* === PRINT STABILITY RULES (voorblad + ondertekenen) === */
@@ -659,7 +671,7 @@ page-break-inside: avoid;
 
 
 /* 2) Ondertekenen: vaste kolommen, geen wrap/glitches */
-.signature-row{ display:flex; page-break-inside: avoid; }
+.signature-row{ display:flex; page-break-inside: avoid; align-items:flex-start; }
 .signature-col{ flex:0 0 48%; box-sizing:border-box; }
 .signature-col + .signature-col{ margin-left:4%; }
 


### PR DESCRIPTION
## Summary
- Move cover text slightly downward for export
- Inline custom bullet styling for notes export
- Align signature fields on notes page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68affbab87e88330be7cd386faa16665