### PR TITLE
Use custom bullet image for ACW lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,14 @@
     /* Toelichting */
     .raj-title{ font-family:'Rajdhani', sans-serif; font-weight:700 }
     .acw-ul{ list-style:none; padding-left:0; margin:8px 0 0 }
-    .acw-ul li{ position:relative; padding-left:20px; margin:6px 0; font-size:10pt }
-    .acw-ul li::before{ content:'•'; position:absolute; left:0; top:0.2em; font-size:14px; color:var(--acw-red); }
+    .acw-ul li{
+      position:relative;
+      padding-left:20px;
+      margin:6px 0;
+      font-size:10pt;
+      background:url('https://www.acwbv.nl/wp-content/uploads/2025/08/Bulletpoint-ACW.png') no-repeat 0 0.95em;
+      background-size:11px 11px;
+    }
 
     .note{ padding:10px 12px; background:#f3f4f6; border:1px solid #e5e7eb; border-radius:10px; font-size:14px }
     .ok{ color:#065f46; background:#ecfdf5; border-color:#a7f3d0 }
@@ -649,8 +655,7 @@
             table.pricetable th{ background:#D52B1E; color:#fff; font-weight:700 }
             table.pricetable td.bold{ font-weight:700 }
             .acw-ul{ list-style:none; padding-left:0; margin:8px 0 0 }
-            .acw-ul li{ position:relative; padding-left:20px; margin:6px 0; font-size:10pt }
-            .acw-ul li::before{ content:'•'; position:absolute; left:0; top:0.2em; font-size:14px; color:#D52B1E; }
+            .acw-ul li{ position:relative; padding-left:20px; margin:6px 0; font-size:10pt; background:url('https://www.acwbv.nl/wp-content/uploads/2025/08/Bulletpoint-ACW.png') no-repeat 0 0.95em; background-size:11px 11px; }
             .sign-title{ margin-top:24px; margin-bottom:10px; font-size:10pt }
             .sign-left img{ height:100px; display:block; margin-bottom:8px }
             .sign-right{ margin-top:108px }


### PR DESCRIPTION
## Summary
- Replace list bullets with branded ACW bullet image in preview styles
- Mirror bullet image styling in print/export styles for consistent output

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b00e44efc8833081a299bd32fa9b5c