### PR TITLE
Show yearly cost for one-time posts and add post descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,7 +439,7 @@
 
         if(DRAFT.kind==='specialist'){
           wrap.className='';
-          if(!Array.isArray(DRAFT.pricing.posts)) DRAFT.pricing.posts=[{price:0,freq:'once',turns:0}];
+          if(!Array.isArray(DRAFT.pricing.posts)) DRAFT.pricing.posts=[{price:0,freq:'once',turns:0,desc:''}];
 
           function renderPosts(){
             wrap.innerHTML='';
@@ -447,11 +447,12 @@
               const block=document.createElement('div');
               block.className='spec-post';
               block.innerHTML=`<div style=\"font-weight:700;margin-bottom:6px\">Post ${idx+1}</div>
+              <div><label>Omschrijving</label><input data-field=\"desc\" placeholder=\"Bijv. tapijtreiniging\" value=\"${esc(post.desc||'')}\"></div>
               <div class=\"row\">
                 <div class=\"currency\"><label>Prijs per beurt *</label><span class=\"prefix\">€</span><input data-field=\"price\" inputmode=\"decimal\" placeholder=\"0,00\" value=\"${post.price?post.price.toString().replace('.',','):''}\"></div>
                 <div><label>Frequentie *</label><select data-field=\"freq\"><option value=\"\">Kies...</option><option value=\"once\"${post.freq==='once'? ' selected':''}>Éénmalig</option><option value=\"multi\"${post.freq==='multi'? ' selected':''}>Meerdere keren</option></select></div>
                 <div class=\"turns ${post.freq==='multi'?'':'hidden'}\"><label>Beurten per jaar *</label><input type=\"number\" min=\"1\" step=\"1\" data-field=\"turns\" value=\"${post.turns||''}\"></div>
-                <div class=\"currency yearly ${post.freq==='multi'?'':'hidden'}\"><label>Prijs per jaar</label><span class=\"prefix\">€</span><input data-field=\"yearly\" readonly value=\"${post.freq==='multi'?euro((post.price||0)*(post.turns||0)):''}\"></div>
+                <div class=\"currency yearly\"><label>Prijs per jaar/Totale prijs</label><span class=\"prefix\">€</span><input data-field=\"yearly\" readonly value=\"${post.freq==='multi'?euro((post.price||0)*(post.turns||0)):post.price?euro(post.price):''}\"></div>
               </div>
               <button class=\"remove\" title=\"Verwijderen\">&times;</button>`;
 
@@ -459,30 +460,34 @@
               const freq=block.querySelector('[data-field=freq]');
               const turns=block.querySelector('[data-field=turns]');
               const yearly=block.querySelector('[data-field=yearly]');
+              const desc=block.querySelector('[data-field=desc]');
               function sync(){
                 post.price=parseDec(price.value||0)||0;
                 post.freq=freq.value||'';
+                post.desc=desc.value||'';
                 if(post.freq==='multi'){
                   post.turns=Number(turns.value||0);
                   const y=(post.price||0)*(post.turns||0);
                   post.yearly=y; yearly.value=euro(y);
                 }else{
-                  post.turns=0; post.yearly=0; if(turns) turns.value=''; yearly.value='';
+                  post.turns=0; if(turns) turns.value='';
+                  const y=(post.price||0);
+                  post.yearly=y; yearly.value=post.price?euro(y):'';
                 }
               }
               price.addEventListener('input',sync);
               freq.addEventListener('change',()=>{
                 block.querySelector('.turns').classList.toggle('hidden',freq.value!=='multi');
-                block.querySelector('.yearly').classList.toggle('hidden',freq.value!=='multi');
                 sync();
               });
+              desc.addEventListener('input',sync);
               turns && turns.addEventListener('input',sync);
               block.querySelector('.remove').addEventListener('click',()=>{ DRAFT.pricing.posts.splice(idx,1); renderPosts(); });
               wrap.appendChild(block);
             });
             const addBtn=document.createElement('button');
             addBtn.className='note-add'; addBtn.textContent='+'; addBtn.title='Post toevoegen';
-            addBtn.addEventListener('click',()=>{ DRAFT.pricing.posts.push({price:0,freq:'once',turns:0}); renderPosts(); });
+            addBtn.addEventListener('click',()=>{ DRAFT.pricing.posts.push({price:0,freq:'once',turns:0,desc:''}); renderPosts(); });
             wrap.appendChild(addBtn);
           }
 
@@ -549,13 +554,14 @@
         html+=`<table class=\"pricetable\">`;
 
         if(DRAFT.kind==='specialist'){
-          html+=`<thead><tr><th>Post</th><th>Prijs per beurt</th><th>Frequentie</th><th>Prijs per jaar</th></tr></thead><tbody>`;
+          html+=`<thead><tr><th>Post</th><th>Prijs per beurt</th><th>Frequentie</th><th>Prijs per jaar/Totale prijs</th></tr></thead><tbody>`;
           let total=0;
           p.posts.forEach((post,idx)=>{
             const freqText=post.freq==='multi'?`${post.turns}x per jaar`:'Éénmalig';
-            const yearly=post.freq==='multi'? (post.price||0)*(post.turns||0) : 0;
+            const yearly=post.freq==='multi'? (post.price||0)*(post.turns||0) : (post.price||0);
             if(yearly>0) total+=yearly;
-            html+=`<tr><td class=\"bold\">Post ${idx+1}</td><td class=\"bold\">${euro(post.price)}</td><td>${esc(freqText)}</td><td>${yearly?euro(yearly):'-'}</td></tr>`;
+            const label=post.desc?`Post ${idx+1}: ${esc(post.desc)}`:`Post ${idx+1}`;
+            html+=`<tr><td class=\"bold\">${label}</td><td class=\"bold\">${euro(post.price)}</td><td>${esc(freqText)}</td><td>${yearly?euro(yearly):'-'}</td></tr>`;
           });
           html+=`</tbody>`;
           if(total>0) html+=`<tfoot><tr><td colspan=\"3\">Totaal per jaar</td><td>${euro(total)}</td></tr></tfoot>`;


### PR DESCRIPTION
## Summary
- Show annual cost for posts marked one-time and update header to "Prijs per jaar/Totale prijs"
- Add description input for each post and include it in the pricing overview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14c0b50dc83308b539e56cba80560