### PR TITLE
Ondersteun meerdere posten bij reguliere schoonmaak

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,44 +495,137 @@
           return;
         }
 
+        if(DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa'){
+          wrap.className='';
+          if(!Array.isArray(DRAFT.pricing.posts)) DRAFT.pricing.posts=[{type:'',desc:'',price:0,billing:'',highFreq:'',sp_price:0,sp_freq:'once',sp_turns:0}];
+
+          function renderRegPosts(){
+            wrap.innerHTML='';
+            DRAFT.pricing.posts.forEach((post,idx)=>{
+              const block=document.createElement('div');
+              block.className='spec-post';
+              block.innerHTML=`<div style=\"font-weight:700;margin-bottom:6px\">Post ${idx+1}</div>
+              <div><label>Frequentie</label><select data-field=\"type\"><option value=\"\">Kies...</option><option value=\"regular\"${post.type==='regular'?' selected':''}>Regulier</option><option value=\"once\"${post.type==='once'?' selected':''}>Éénmalig</option></select></div>
+              <div class=\"desc-field ${post.type?'':'hidden'}\"><label>Omschrijving</label><input data-field=\"desc\" value=\"${esc(post.desc||'')}\"></div>
+              <div class=\"regular-fields ${post.type==='regular'?'':'hidden'}\"><div class=\"row\">
+                <div class=\"currency\"><label>Prijs *</label><span class=\"prefix\">€</span><input data-field=\"price\" inputmode=\"decimal\" placeholder=\"0,00\" value=\"${post.price?post.price.toString().replace('.',','):''}\"></div>
+                <div><label>Facturatieschema *</label><select data-field=\"billing\"><option value=\"\">Kies...</option><option value=\"maand\"${post.billing==='maand'?' selected':''}>Per maand</option><option value=\"4w\"${post.billing==='4w'?' selected':''}>Per periode (4 weken)</option></select></div>
+                <div><label>Hoogste frequentie *</label><select data-field=\"highFreq\"><option value=\"\">Kies...</option><option>5x per week</option><option>4x per week</option><option>3x per week</option><option>2x per week</option><option>1x per week</option><option>1x per maand</option><option>6x per jaar</option><option>4x per jaar</option><option>1x per jaar</option></select></div>
+              </div></div>
+              <div class=\"once-fields ${post.type==='once'?'':'hidden'}\"><div class=\"row\">
+                <div class=\"currency\"><label>Prijs per beurt *</label><span class=\"prefix\">€</span><input data-field=\"sp_price\" inputmode=\"decimal\" placeholder=\"0,00\" value=\"${post.sp_price?post.sp_price.toString().replace('.',','):''}\"></div>
+                <div><label>Frequentie *</label><select data-field=\"sp_freq\"><option value=\"\">Kies...</option><option value=\"once\"${post.sp_freq==='once'?' selected':''}>Éénmalig</option><option value=\"multi\"${post.sp_freq==='multi'?' selected':''}>Meerdere keren</option></select></div>
+                <div class=\"turns ${post.sp_freq==='multi'?'':'hidden'}\"><label>Beurten per jaar *</label><input type=\"number\" min=\"1\" step=\"1\" data-field=\"sp_turns\" value=\"${post.sp_turns||''}\"></div>
+                <div class=\"currency yearly\"><label>Prijs per jaar/Totale prijs</label><span class=\"prefix\">€</span><input data-field=\"sp_yearly\" readonly value=\"${post.sp_freq==='multi'?euro((post.sp_price||0)*(post.sp_turns||0)):post.sp_price?euro(post.sp_price):''}\"></div>
+              </div></div>
+              <button class=\"remove\" title=\"Verwijderen\">&times;</button>`;
+
+              const desc=block.querySelector('[data-field=desc]');
+              const type=block.querySelector('[data-field=type]');
+              const price=block.querySelector('[data-field=price]');
+              const billing=block.querySelector('[data-field=billing]');
+              const highFreq=block.querySelector('[data-field=highFreq]');
+              const sp_price=block.querySelector('[data-field=sp_price]');
+              const sp_freq=block.querySelector('[data-field=sp_freq]');
+              const sp_turns=block.querySelector('[data-field=sp_turns]');
+              const sp_yearly=block.querySelector('[data-field=sp_yearly]');
+
+              function sync(){
+                  post.desc=desc.value||'';
+                  post.type=type.value||'';
+                if(post.type==='regular'){
+                  post.price=parseDec(price.value||0)||0;
+                  post.billing=billing.value||'';
+                  post.highFreq=highFreq.value||'';
+                }else if(post.type==='once'){
+                  post.sp_price=parseDec(sp_price.value||0)||0;
+                  post.sp_freq=sp_freq.value||'';
+                  if(post.sp_freq==='multi'){
+                    post.sp_turns=Number(sp_turns.value||0);
+                    const y=(post.sp_price||0)*(post.sp_turns||0);
+                    post.sp_yearly=y; sp_yearly.value=euro(y);
+                  }else{
+                    post.sp_turns=0; if(sp_turns) sp_turns.value='';
+                    const y=(post.sp_price||0);
+                    post.sp_yearly=y; sp_yearly.value=post.sp_price?euro(y):'';
+                  }
+                }else{
+                  post.price=0; post.billing=''; post.highFreq='';
+                  post.sp_price=0; post.sp_freq='once'; post.sp_turns=0; post.sp_yearly=0;
+                }
+              }
+
+              desc.addEventListener('input',sync);
+              type.addEventListener('change',()=>{
+                block.querySelector('.regular-fields').classList.toggle('hidden',type.value!=='regular');
+                block.querySelector('.once-fields').classList.toggle('hidden',type.value!=='once');
+                block.querySelector('.desc-field').classList.toggle('hidden',!type.value);
+                sync();
+              });
+              price && price.addEventListener('input',sync);
+              billing && billing.addEventListener('change',sync);
+              highFreq && highFreq.addEventListener('change',sync);
+              sp_price && sp_price.addEventListener('input',sync);
+              sp_freq && sp_freq.addEventListener('change',()=>{
+                block.querySelector('.turns').classList.toggle('hidden',sp_freq.value!=='multi');
+                sync();
+              });
+              sp_turns && sp_turns.addEventListener('input',sync);
+              sync();
+              block.querySelector('.remove').addEventListener('click',()=>{ DRAFT.pricing.posts.splice(idx,1); renderRegPosts(); });
+              wrap.appendChild(block);
+            });
+            const addBtn=document.createElement('button');
+            addBtn.className='note-add'; addBtn.textContent='+'; addBtn.title='Post toevoegen';
+            addBtn.addEventListener('click',()=>{ DRAFT.pricing.posts.push({type:'',desc:'',price:0,billing:'',highFreq:'',sp_price:0,sp_freq:'once',sp_turns:0}); renderRegPosts(); });
+            wrap.appendChild(addBtn);
+          }
+
+          renderRegPosts();
+          return;
+        }
+
         wrap.className='row';
         let html='';
-        if(DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa'){
-          html+=`<div class=\"currency\"><label>Prijs *</label><span class=\"prefix\">€</span><input id=\"price\" inputmode=\"decimal\" placeholder=\"0,00\"></div>`;
-          html+=`<div><label>Facturatieschema *</label><select id=\"billing\"><option value=\"\">Kies...</option><option value=\"maand\">Per maand</option><option value=\"4w\">Per periode (4 weken)</option></select></div>`;
-          html+=`<div><label>Hoogste frequentie *</label><select id=\"highFreq\"><option value=\"\">Kies...</option><option>5x per week</option><option>4x per week</option><option>3x per week</option><option>2x per week</option><option>1x per week</option><option>1x per maand</option></select></div>`;
-        } else if(DRAFT.kind==='glass'){
+        if(DRAFT.kind==='glass'){
           html+=`<div class=\"currency\"><label>Prijs (per beurt) *</label><span class=\"prefix\">€</span><input id=\"price\" inputmode=\"decimal\" placeholder=\"0,00\"></div>`;
           html+=`<div><label>Frequentie (per jaar) *</label><input id=\"freq\" type=\"number\" min=\"1\" step=\"1\" placeholder=\"Bijv. 4\"></div>`;
           html+=`<div><label>Prijs per jaar</label><input id=\"yearly\" readonly></div>`;
         }
         wrap.innerHTML=html;
 
-        const price=el('price'), billing=el('billing'), freq=el('freq'), yearly=el('yearly'), highFreq=el('highFreq');
+        const price=el('price'), freq=el('freq'), yearly=el('yearly');
         function sync(){
           if(price) DRAFT.pricing.price = parseDec(price.value||0) || 0;
-          if(billing) DRAFT.pricing.billing = billing.value||'';
           if(freq) DRAFT.pricing.frequency = Number(freq.value||0);
-          if(highFreq) DRAFT.pricing.highFreq = highFreq.value||'';
           if(yearly && DRAFT.kind==='glass'){
             const y=(DRAFT.pricing.price||0)*(DRAFT.pricing.frequency||0);
             yearly.value=euro(y); DRAFT.pricing.yearly=y;
           }
         }
         price && price.addEventListener('input',sync);
-        billing && billing.addEventListener('change',sync);
         freq && freq.addEventListener('input',sync);
-        highFreq && highFreq.addEventListener('change',sync);
         sync();
       }
 
       // Prijzenoverzicht preview
       el('btnUpdatePricePreview').addEventListener('click',()=>{
         if(!DRAFT.kind){ alert('Kies eerst een offertetype.'); return; }
-        if((DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa')){
-          if(!(DRAFT.pricing.price>0)){ alert('Vul een geldige prijs in.'); return; }
-          if(!DRAFT.pricing.billing){ alert('Kies een facturatieschema.'); return; }
-          if(!DRAFT.pricing.highFreq){ alert('Kies de hoogste frequentie.'); return; }
+        if(DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa'){
+          const posts=DRAFT.pricing.posts||[];
+          if(!posts.length){ alert('Voeg minimaal één post toe.'); return; }
+          for(const post of posts){
+            if(!post.type){ alert('Kies een frequentie voor elke post.'); return; }
+            if(post.type==='regular'){
+              if(!(post.price>0)){ alert('Vul een geldige prijs in.'); return; }
+              if(!post.billing){ alert('Kies een facturatieschema.'); return; }
+              if(!post.highFreq){ alert('Kies de hoogste frequentie.'); return; }
+            }else{
+              if(!(post.sp_price>0)){ alert('Vul een geldige prijs per beurt in.'); return; }
+              if(!post.sp_freq){ alert('Kies een frequentie.'); return; }
+              if(post.sp_freq==='multi' && !(post.sp_turns>0)){ alert('Vul geldige beurten per jaar in.'); return; }
+            }
+          }
         }
         if(DRAFT.kind==='specialist'){
           const posts=DRAFT.pricing.posts||[];
@@ -565,27 +658,36 @@
           });
           html+=`</tbody>`;
           if(total>0) html+=`<tfoot><tr><td colspan=\"3\">Totaal per jaar/Totale prijs</td><td>${euro(total)}</td></tr></tfoot>`;
-        } else {
+        } else if(DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa'){
+          html+=`<thead><tr><th>Post</th><th>Prijs</th><th>Frequentie</th><th>Prijs per jaar/Totale prijs</th></tr></thead><tbody>`;
+          let total=0;
+          p.posts.forEach((post,idx)=>{
+            if(post.type==='regular'){
+              const priceLabel = post.billing==='maand'? 'p/m' : 'p/4w';
+              const label=post.desc?`Post ${idx+1}: ${esc(post.desc)}`:`Post ${idx+1}`;
+              html+=`<tr><td class=\"bold\">${label}</td><td class=\"bold\">${euro(post.price)} ${priceLabel}</td><td>${esc(post.highFreq)}</td><td>-</td></tr>`;
+            }else if(post.type==='once'){
+              const freqText=post.sp_freq==='multi'?`${post.sp_turns}x per jaar`:'Éénmalig';
+              const yearly=post.sp_freq==='multi'? (post.sp_price||0)*(post.sp_turns||0) : (post.sp_price||0);
+              if(yearly>0) total+=yearly;
+              const label=post.desc?`Post ${idx+1}: ${esc(post.desc)}`:`Post ${idx+1}`;
+              html+=`<tr><td class=\"bold\">${label}</td><td class=\"bold\">${euro(post.sp_price)}</td><td>${esc(freqText)}</td><td>${yearly?euro(yearly):'-'}</td></tr>`;
+            }
+          });
+          html+=`</tbody>`;
+          if(total>0) html+=`<tfoot><tr><td colspan=\"3\">Totaal per jaar/Totale prijs</td><td>${euro(total)}</td></tr></tfoot>`;
+        } else if(DRAFT.kind==='glass'){
           const rows=[];
-          if(DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa'){
-            rows.push(['Hoogste frequentie', p.highFreq||'-']);
-            rows.push(['Facturatieschema', p.billing==='maand'?'Per maand':'Per periode (4 weken)']);
-            const prijsLabel=p.billing==='maand'?'Prijs per maand':'Prijs per periode';
-            rows.push([prijsLabel, euro(p.price)]);
-          } else if(DRAFT.kind==='glass'){
-            rows.push(['Frequentie (per jaar)', p.frequency]);
-            rows.push(['Prijs per beurt', euro(p.price)]);
-            rows.push(['Prijs per jaar', euro((p.price||0)*(p.frequency||0))]);
-          }
+          rows.push(['Frequentie (per jaar)', p.frequency]);
+          rows.push(['Prijs per beurt', euro(p.price)]);
+          rows.push(['Prijs per jaar', euro((p.price||0)*(p.frequency||0))]);
           html+=`<thead><tr><th>Omschrijving</th><th>Waarde</th></tr></thead><tbody>`;
           rows.forEach(([label,val])=>{
             const isPrice=/^Prijs/i.test(label);
             html+=`<tr><td class=\"${isPrice?'bold':''}\">${esc(label)}</td><td class=\"${isPrice?'bold':''}\">${typeof val==='string'?esc(val):val}</td></tr>`;
           });
           html+=`</tbody>`;
-          if(DRAFT.kind==='glass'){
-            html+=`<tfoot><tr><td>Totaal per jaar</td><td>${euro((p.price||0)*(p.frequency||0))}</td></tr></tfoot>`;
-          }
+          html+=`<tfoot><tr><td>Totaal per jaar</td><td>${euro((p.price||0)*(p.frequency||0))}</td></tr></tfoot>`;
         }
 
         html+=`</table>`;


### PR DESCRIPTION
## Samenvatting
- Voeg mogelijkheid toe om meerdere posten aan reguliere schoonmaak toe te voegen met omschrijving en frequentiekeuze.
- Breid keuzelijst voor hoogste frequentie uit met 6x, 4x en 1x per jaar.
- Toon alle posten in prijzenoverzichtstabel inclusief reguliere en eenmalige posten.

## Testen
- `npm test` *(faalt: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b165923d1c83309c4e6994c8f1973d