### PR TITLE
Fix PDF print missing cover and letterheads

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,11 +946,16 @@
             c.replaceWith(img);
           }
         });
-        node.querySelectorAll('.letter-bg').forEach(bg=>{
-          const cs=getComputedStyle(bg);
-          bg.style.backgroundImage=cs.backgroundImage;
-          bg.style.backgroundSize=cs.backgroundSize;
-          bg.style.backgroundPosition=cs.backgroundPosition;
+        const origBgs=elm.querySelectorAll('.letter-bg, .cover-photo, .cover-overlay');
+        const cloneBgs=node.querySelectorAll('.letter-bg, .cover-photo, .cover-overlay');
+        cloneBgs.forEach((bg,i)=>{
+          const src=origBgs[i];
+          if(src){
+            const cs=getComputedStyle(src);
+            bg.style.backgroundImage=cs.backgroundImage;
+            bg.style.backgroundSize=cs.backgroundSize;
+            bg.style.backgroundPosition=cs.backgroundPosition;
+          }
         });
         await inlineAssets(node);
         node.classList.add('page-break');


### PR DESCRIPTION
## Summary
- Ensure print/export cloning copies background styles from original elements so cover and letter pages retain letterhead imagery.

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68b19161bce88330b2e6e6f520678dbb