### PR TITLE
Use dedicated letterhead images for letter and follow-up pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,8 +353,9 @@
       const labels={regular_office:'Reguliere schoonmaak kantoren', regular_hoa:"Reguliere schoonmaak VvE's", specialist:'Specialistische reiniging', glass:'Glasbewassing'};
       const DRAFT=window.DRAFT||{ kind:null, meta:{}, pricing:{}, notes:[] }; window.DRAFT=DRAFT;
 
-      // Local letterhead to avoid cross‑origin issues
-      const LETTER_BG_DATA="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc1OTUnIGhlaWdodD0nODQyJz48cmVjdCB3aWR0aD0nMTAwJScgaGVpZ2h0PScxMDAlJyBmaWxsPSd3aGl0ZScvPjx0ZXh0IHg9JzUwJScgeT0nNDAnIGZvbnQtc2l6ZT0nMjQnIHRleHQtYW5jaG9yPSdtaWRkbGUnIGZpbGw9J2dyYXknPkxldHRlcmhlYWQ8L3RleHQ+PC9zdmc+";
+      // Letterhead images
+      const LETTER_BG_FRONT = "https://www.acwbv.nl/wp-content/uploads/2025/08/Briefpapier_Schoonmaak_2024-1_page-0001.jpg";
+      const LETTER_BG_OTHER = "https://www.acwbv.nl/wp-content/uploads/2025/08/Briefpapier-overige-pagina-1.jpg";
 
       // Utils
       const euro=n=>`€ ${Number(n||0).toLocaleString('nl-NL',{minimumFractionDigits:2, maximumFractionDigits:2})}`;
@@ -456,7 +457,7 @@
         html+=`<div class=\"signature\">Met vriendelijke groet,<br><br>${sig?`<img src=\"${sig}\" style=\"height:100px\" alt=\"Handtekening\"><br>`:''}ACW<br>${esc(m.makerName||'')}<br><em>${esc(role)}</em></div>`;
 
         el('letterContent').innerHTML=html;
-        el('letterBg').style.backgroundImage=`url('${LETTER_BG_DATA}')`;
+        el('letterBg').style.backgroundImage=`url('${LETTER_BG_FRONT}')`;
         document.getElementById('letterSection').scrollIntoView({behavior:'smooth'});
       });
       el('btnApproveLetter').addEventListener('click',()=>{ el('approveNote').classList.remove('hidden'); document.getElementById('pricingSection').scrollIntoView({behavior:'smooth'}); });
@@ -731,7 +732,7 @@
         html+=`</table>`;
 
         el('priceContent').innerHTML=html;
-        el('priceBg').style.backgroundImage=`url('${LETTER_BG_DATA}')`;
+        el('priceBg').style.backgroundImage=`url('${LETTER_BG_OTHER}')`;
         document.getElementById('pricesheetSection').scrollIntoView({behavior:'smooth'});
       });
 
@@ -753,7 +754,7 @@
           const ext=(file.name.split('.').pop()||'').toLowerCase();
           const container=el('workprogPreview');
           container.innerHTML='';
-          const letterBg=`url('${LETTER_BG_DATA}')`;
+          const letterBg=`url('${LETTER_BG_OTHER}')`;
           if(['xls','xlsx','xlsm','xlsb','csv'].includes(ext)){
             const buf=await file.arrayBuffer();
             const wb=XLSX.read(buf,{type:'array'});
@@ -852,7 +853,7 @@
         html+=`</div>`;
 
         el('notesContent').innerHTML=html;
-        el('notesBg').style.backgroundImage = `url('${LETTER_BG_DATA}')`;
+        el('notesBg').style.backgroundImage = `url('${LETTER_BG_OTHER}')`;
         document.getElementById('notesPreviewSection').scrollIntoView({behavior:'smooth'});
       }
       el('btnUpdateNotesPreview').addEventListener('click',buildNotesPreview);


### PR DESCRIPTION
## Summary
- Add separate constants for front-page and subsequent-page letterhead images
- Apply front letterhead to voorbrief and alternate letterhead to pricing, work program, and notes sections

## Testing
- `npx --yes prettier --check index.html` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19cfa0bfc83308333c53c97007183