### PR TITLE
Switch work program upload from Excel to PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Rajdhani:wght@500;700&display=swap" rel="stylesheet">
   <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/xlsx@0.19.2/dist/xlsx.full.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.js"></script>
   <style>
     :root{ --acw-red:#D52B1E; --acw-black:#222222 }
     *{ box-sizing:border-box }
@@ -58,6 +58,7 @@
     /* Werkprogramma */
     .workprog-body table{ width:100%; border-collapse:collapse; }
     .workprog-body td, .workprog-body th{ border:1px solid #e5e7eb; padding:4px; font-size:10pt }
+    .workprog-body img{ width:100%; }
 
     /* Toelichting */
     .raj-title{ font-family:'Rajdhani', sans-serif; font-weight:700 }
@@ -242,7 +243,7 @@
           <div class="chip" data-choice="no">Nee</div>
         </div>
         <div id="workprogUpload" class="hidden" style="margin-top:10px">
-          <input type="file" id="workprogFile" accept=".xls,.xlsx,.xlsm,.xlsb,.csv" />
+          <input type="file" id="workprogFile" accept=".pdf" />
           <div class="actions" style="margin-top:10px"><button id="btnWorkprogPreview" class="btn">Voorbeeld bijwerken</button></div>
         </div>
         <div id="workprogPreview"></div>
@@ -358,6 +359,9 @@
       const esc=s=>(s||'').replace(/[&<>]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
       const nl2br=s=>esc(s).replace(/\n/g,'<br>');
       const getBgUrl=(el)=>{ if(!el) return ''; const bi=getComputedStyle(el).backgroundImage; const m=/url\(["']?(.*?)["']?\)/.exec(bi||''); return m?m[1]:''; };
+
+      const pdfjsLib = window['pdfjsLib'];
+      pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js';
 
       // TYPE chips
       document.querySelectorAll('#typeChips .chip').forEach(ch=>ch.addEventListener('click',()=>{
@@ -742,18 +746,23 @@
         const file=el('workprogFile').files[0];
         if(!file){ alert('Kies een bestand.'); return; }
         const buf=await file.arrayBuffer();
-        const wb=XLSX.read(buf,{type:'array'});
+        const pdf=await pdfjsLib.getDocument({data:buf}).promise;
         const container=el('workprogPreview');
         container.innerHTML='';
-        wb.SheetNames.forEach(name=>{
-          const ws=wb.Sheets[name];
-          const html=XLSX.utils.sheet_to_html(ws,{header:'',footer:''});
+        for(let i=1;i<=pdf.numPages;i++){
+          const pg=await pdf.getPage(i);
+          const viewport=pg.getViewport({scale:1.5});
+          const canvas=document.createElement('canvas');
+          const ctx=canvas.getContext('2d');
+          canvas.width=viewport.width; canvas.height=viewport.height;
+          await pg.render({canvasContext:ctx, viewport}).promise;
+          const img=canvas.toDataURL('image/png');
           const page=document.createElement('div');
           page.className='letter';
-          page.innerHTML=`<div class="letter-bg"></div><div class="letter-body workprog-body">${html}</div>`;
+          page.innerHTML=`<div class="letter-bg"></div><div class="letter-body workprog-body"><img src="${img}"></div>`;
           page.querySelector('.letter-bg').style.backgroundImage="url('https://www.acwbv.nl/wp-content/uploads/2025/08/Briefpapier-overige-pagina-1.jpg')";
           container.appendChild(page);
-        });
+        }
         if(container.firstElementChild){ container.firstElementChild.scrollIntoView({behavior:'smooth'}); }
       });
 


### PR DESCRIPTION
## Summary
- Replace Excel upload with PDF upload for work programs
- Render each PDF page with pdf.js and include as separate letter pages
- Add PDF.js library and adjust styles for image-based work programs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b553c3d7cc8330938c2708806b6f29