### PR TITLE
Handle absence of PDF.js in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,11 @@
       const getBgUrl=(el)=>{ if(!el) return ''; const bi=getComputedStyle(el).backgroundImage; const m=/url\(["']?(.*?)["']?\)/.exec(bi||''); return m?m[1]:''; };
 
       const pdfjsLib = window['pdfjsLib'];
-      pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js';
+      if (pdfjsLib) {
+        pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js';
+      } else {
+        console.warn('PDF.js niet geladen; functionaliteit beperkt.');
+      }
 
       // TYPE chips
       document.querySelectorAll('#typeChips .chip').forEach(ch=>ch.addEventListener('click',()=>{


### PR DESCRIPTION
## Summary
- Safely configure PDF.js worker only when library is present and warn otherwise

## Testing
- ⚠️ `npm install jsdom` *(403 Forbidden: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b559804dfc8330be5f5b800e1f37d0