### PR TITLE
Render uploaded work program PDF in preview and export

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,17 @@
       }
       return !!window.html2pdf;
     }
+    async function ensurePdfJs(){
+      if(window.pdfjsLib) return window.pdfjsLib;
+      await new Promise(res=>{
+        const t=setInterval(()=>{ if(window.pdfjsLib){ clearInterval(t); res(); } },50);
+      });
+      const lib=window.pdfjsLib;
+      if(lib && lib.GlobalWorkerOptions){
+        lib.GlobalWorkerOptions.workerSrc='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js';
+      }
+      return lib;
+    }
   </script>
 
   <script>
@@ -360,12 +371,7 @@
       const nl2br=s=>esc(s).replace(/\n/g,'<br>');
       const getBgUrl=(el)=>{ if(!el) return ''; const bi=getComputedStyle(el).backgroundImage; const m=/url\(["']?(.*?)["']?\)/.exec(bi||''); return m?m[1]:''; };
 
-      const pdfjsLib = window['pdfjsLib'];
-      if (pdfjsLib) {
-        pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js';
-      } else {
-        console.warn('PDF.js niet geladen; functionaliteit beperkt.');
-      }
+      ensurePdfJs().catch(()=>console.warn('PDF.js niet geladen; functionaliteit beperkt.'));
 
       // TYPE chips
       document.querySelectorAll('#typeChips .chip').forEach(ch=>ch.addEventListener('click',()=>{
@@ -747,6 +753,8 @@
         }
       }));
       el('btnWorkprogPreview').addEventListener('click', async ()=>{
+        const pdfjsLib = await ensurePdfJs();
+        if(!pdfjsLib){ alert('PDF-bibliotheek kon niet geladen worden.'); return; }
         const file=el('workprogFile').files[0];
         if(!file){ alert('Kies een bestand.'); return; }
         const buf=await file.arrayBuffer();
@@ -967,6 +975,7 @@
             .page{ width:210mm; height:297mm; position:relative; page-break-after:always; overflow:hidden; font-family:'Inter',sans-serif; }
             .bg-img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover }
             .body{ position:relative; padding:28mm 22mm 24mm 22mm; font-size:10pt; line-height:1.5 }
+            .workprog-body img{ width:100%; }
             .cover-body{ position:relative; font-family:'Rajdhani', sans-serif; font-weight:500; color:#fff; }
             .cover-text{ position:absolute; top:205mm; left:28mm; width:90mm; display:flex; justify-content:space-between; gap:1px; }
             .cover-col{ width:48% }


### PR DESCRIPTION
## Summary
- Load PDF.js on demand to process uploaded work program documents
- Display uploaded work program PDFs in preview and include in exports and print outputs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b55dd2094c8330b43d8ad0638de2ee