### PR TITLE
Ensure pdf.js loads before work program upload processing

### DIFF
--- a/WerkprogrammaUploader.js
+++ b/WerkprogrammaUploader.js
@@ -10,6 +10,11 @@
       const f = ev.target.files[0];
       if(!f) return;
       setFile(f);
+      if(!window.pdfjsLib){
+        if(window.ensurePdfJs){
+          await window.ensurePdfJs();
+        }
+      }
       if(!window.pdfjsLib){ console.error('pdfjsLib missing'); return; }
       pdfjsLib.GlobalWorkerOptions.workerSrc = 'lib/pdf.js/pdf.worker.min.js';
       const buffer = await f.arrayBuffer();


### PR DESCRIPTION
## Summary
- Load pdf.js on demand before rendering the uploaded work program so the preview and export display correctly.

## Testing
- `node --check WerkprogrammaUploader.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5949420cc83309ed7a48965aa2e1b