### PR TITLE
Ensure uploaded PDF pages print with content

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,9 +934,19 @@
           const letters=sec.querySelectorAll('.letter'); if(!letters.length) return;
           letters.forEach(page=>{
             if(id==='coverPreviewSection'){
-              pages.push({ type:'cover', photoUrl:getBgUrl(page.querySelector('.cover-photo')), overlayUrl:getBgUrl(page.querySelector('.cover-overlay')), bodyHTML: page.querySelector('.cover-body')?.innerHTML||'' });
+              pages.push({
+                type:'cover',
+                photoUrl:getBgUrl(page.querySelector('.cover-photo')),
+                overlayUrl:getBgUrl(page.querySelector('.cover-overlay')),
+                bodyHTML: page.querySelector('.cover-body')?.innerHTML||''
+              });
             } else {
-              pages.push({ type:'letter', bgUrl:getBgUrl(page.querySelector('.letter-bg')), bodyHTML: page.querySelector('.letter-body')?.innerHTML||'' });
+              const bodyHTML = page.querySelector('.letter-body')?.innerHTML || page.innerHTML;
+              pages.push({
+                type:'letter',
+                bgUrl:getBgUrl(page.querySelector('.letter-bg')),
+                bodyHTML
+              });
             }
           });
         });


### PR DESCRIPTION
## Summary
- fix print fallback so PDF pages rendered as simple images are exported with their content

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b800566f4c8330abc38a302b20f740