### PR TITLE
Use reference as print PDF title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1041,6 +1041,7 @@
         const doc=iframe.contentDocument || iframe.contentWindow.document;
         doc.open();
         const ref = (DRAFT.meta.ourRef || 'ACW-offerte').replace(/[^\w\d-]+/g,'_');
+        const prevTitle=document.title;
         doc.write(`<!DOCTYPE html><html><head><meta charset="utf-8"><title>${ref}</title>
           <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Rajdhani:wght@500;700&display=swap" rel="stylesheet">
           <style>
@@ -1122,8 +1123,15 @@ body{ -webkit-text-size-adjust:100%; text-size-adjust:100%; }
         const imgs=doc.images; const waitImgs=Array.from(imgs).map(img=> new Promise(res=>{ if(img.complete) return res(); img.onload=img.onerror=()=>res(); }));
         await Promise.all(waitImgs);
         iframe.contentWindow.focus();
+        iframe.contentDocument.title = ref;
+        document.title = ref;
         iframe.contentWindow.print();
-        setTimeout(()=>{ document.body.removeChild(iframe); toast.textContent='Printdialoog geopend. Kies "Opslaan als PDF".'; setTimeout(()=>toast.classList.add('hidden'), 4000); }, 500);
+        setTimeout(()=>{
+          document.title = prevTitle;
+          document.body.removeChild(iframe);
+          toast.textContent='Printdialoog geopend. Kies "Opslaan als PDF".';
+          setTimeout(()=>toast.classList.add('hidden'), 4000);
+        }, 500);
       }
 
 // ===== EXPORT (PDF) – raster via html2canvas =====


### PR DESCRIPTION
## Summary
- Preserve current document title and use offer reference for the generated print document
- Restore original title after printing so save-as-PDF uses the reference as filename

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b95fd5ff208330a057b201d7489425