### PR TITLE
Persist quote data and fix yearly price on home

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -128,6 +128,7 @@
     <div class="head">
       <img src="https://www.acwbv.nl/wp-content/uploads/2025/08/LOGO-ACW-RGB-SLOGAN-DIAP-OP-ZWART.png" alt="ACW logo">
       <h1>Offerteplatform</h1>
+      <button id="btnHome" class="btn" style="margin-left:auto">Homepage</button>
     </div>
   </header>
 
@@ -370,6 +371,7 @@
     document.addEventListener('DOMContentLoaded', function(){
       pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.10.111/build/pdf.worker.min.js';
       const el=id=>document.getElementById(id);
+      el('btnHome').addEventListener('click',()=>{ window.location.href='index.html'; });
       const labels={regular_office:'Reguliere schoonmaak kantoren', regular_hoa:"Reguliere schoonmaak VvE's", specialist:'Specialistische reiniging', glass:'Glasbewassing'};
       const DRAFT=window.DRAFT||{ kind:null, meta:{}, pricing:{}, notes:[] }; window.DRAFT=DRAFT;
 
@@ -503,6 +505,15 @@
       function renderPricingFields(){
         const wrap=el('pricingFields'); wrap.innerHTML='';
         const parseDec=v=> Number(String(v).replace(/\./g,'').replace(',','.'));
+        function updateTotal(){
+          let t=0;
+          if(DRAFT.kind==='specialist' && Array.isArray(DRAFT.pricing.posts)){
+            t=DRAFT.pricing.posts.reduce((s,p)=>s+(p.yearly||0),0);
+          }else if((DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa') && Array.isArray(DRAFT.pricing.posts)){
+            t=DRAFT.pricing.posts.reduce((s,p)=>s+(p.type==='regular'?(p.yearly||0):(p.sp_yearly||0)),0);
+          }
+          DRAFT.pricing.yearly=t;
+        }
 
         if(DRAFT.kind==='specialist'){
           wrap.className='';
@@ -541,6 +552,7 @@
                   const y=(post.price||0);
                   post.yearly=y; yearly.value=post.price?euro(y):'';
                 }
+                updateTotal();
               }
               price.addEventListener('input',sync);
               freq.addEventListener('change',()=>{
@@ -549,13 +561,14 @@
               });
               desc.addEventListener('input',sync);
               turns && turns.addEventListener('input',sync);
-              block.querySelector('.remove').addEventListener('click',()=>{ DRAFT.pricing.posts.splice(idx,1); renderPosts(); });
+              block.querySelector('.remove').addEventListener('click',()=>{ DRAFT.pricing.posts.splice(idx,1); renderPosts(); scheduleSave(); });
               wrap.appendChild(block);
             });
             const addBtn=document.createElement('button');
             addBtn.className='note-add'; addBtn.textContent='+'; addBtn.title='Post toevoegen';
-            addBtn.addEventListener('click',()=>{ DRAFT.pricing.posts.push({price:0,freq:'once',turns:0,desc:''}); renderPosts(); });
+            addBtn.addEventListener('click',()=>{ DRAFT.pricing.posts.push({price:0,freq:'once',turns:0,desc:''}); renderPosts(); scheduleSave(); });
             wrap.appendChild(addBtn);
+            updateTotal();
           }
 
           renderPosts();
@@ -627,6 +640,7 @@
                   post.yearly=0; if(yearly) yearly.value='';
                   post.sp_price=0; post.sp_freq='once'; post.sp_turns=0; post.sp_yearly=0;
                 }
+                updateTotal();
               }
 
               desc.addEventListener('input',sync);
@@ -646,13 +660,14 @@
               });
               sp_turns && sp_turns.addEventListener('input',sync);
               sync();
-              block.querySelector('.remove').addEventListener('click',()=>{ DRAFT.pricing.posts.splice(idx,1); renderRegPosts(); });
+              block.querySelector('.remove').addEventListener('click',()=>{ DRAFT.pricing.posts.splice(idx,1); renderRegPosts(); scheduleSave(); });
               wrap.appendChild(block);
             });
             const addBtn=document.createElement('button');
             addBtn.className='note-add'; addBtn.textContent='+'; addBtn.title='Post toevoegen';
-            addBtn.addEventListener('click',()=>{ DRAFT.pricing.posts.push({type:'',desc:'',price:0,billing:'',highFreq:'',yearly:0,sp_price:0,sp_freq:'once',sp_turns:0,sp_yearly:0}); renderRegPosts(); });
+            addBtn.addEventListener('click',()=>{ DRAFT.pricing.posts.push({type:'',desc:'',price:0,billing:'',highFreq:'',yearly:0,sp_price:0,sp_freq:'once',sp_turns:0,sp_yearly:0}); renderRegPosts(); scheduleSave(); });
             wrap.appendChild(addBtn);
+            updateTotal();
           }
 
           renderRegPosts();
@@ -732,6 +747,8 @@
           });
           html+=`</tbody>`;
           if(total>0) html+=`<tfoot><tr><td colspan=\"3\">Totaal per jaar/Totale prijs</td><td>${euro(total)}</td></tr></tfoot>`;
+          DRAFT.pricing.yearly=total;
+          scheduleSave();
         } else if(DRAFT.kind==='regular_office'||DRAFT.kind==='regular_hoa'){
           html+=`<thead><tr><th>Post</th><th>Prijs</th><th>Frequentie</th><th>Prijs per jaar/Totale prijs</th></tr></thead><tbody>`;
           let total=0;
@@ -752,18 +769,23 @@
           });
           html+=`</tbody>`;
           if(total>0) html+=`<tfoot><tr><td colspan=\"3\">Totaal per jaar/Totale prijs</td><td>${euro(total)}</td></tr></tfoot>`;
+          DRAFT.pricing.yearly=total;
+          scheduleSave();
         } else if(DRAFT.kind==='glass'){
           const rows=[];
+          const total=(p.price||0)*(p.frequency||0);
           rows.push(['Frequentie (per jaar)', p.frequency]);
           rows.push(['Prijs per beurt', euro(p.price)]);
-          rows.push(['Prijs per jaar', euro((p.price||0)*(p.frequency||0))]);
+          rows.push(['Prijs per jaar', euro(total)]);
           html+=`<thead><tr><th>Omschrijving</th><th>Waarde</th></tr></thead><tbody>`;
           rows.forEach(([label,val])=>{
             const isPrice=/^Prijs/i.test(label);
             html+=`<tr><td class=\"${isPrice?'bold':''}\">${esc(label)}</td><td class=\"${isPrice?'bold':''}\">${typeof val==='string'?esc(val):val}</td></tr>`;
           });
           html+=`</tbody>`;
-          html+=`<tfoot><tr><td>Totaal per jaar</td><td>${euro((p.price||0)*(p.frequency||0))}</td></tr></tfoot>`;
+          html+=`<tfoot><tr><td>Totaal per jaar</td><td>${euro(total)}</td></tr></tfoot>`;
+          DRAFT.pricing.yearly=total;
+          scheduleSave();
         }
 
         html+=`</table>`;
@@ -887,11 +909,11 @@
         DRAFT.notes.forEach((t,idx)=>{
           const row=document.createElement('div'); row.className='item';
           row.innerHTML=`<span class='bullet'></span> <div style='flex:1'>${esc(t)}</div> <button class='remove' title='Verwijderen'>&times;</button>`;
-          row.querySelector('.remove').addEventListener('click',()=>{ DRAFT.notes.splice(idx,1); renderNotesList(); });
+          row.querySelector('.remove').addEventListener('click',()=>{ DRAFT.notes.splice(idx,1); renderNotesList(); scheduleSave(); });
           list.appendChild(row);
         });
       }
-      el('addNote').addEventListener('click',()=>{ const v=(el('noteInput').value||'').trim(); if(!v) return; DRAFT.notes.push(v); el('noteInput').value=''; renderNotesList(); });
+      el('addNote').addEventListener('click',()=>{ const v=(el('noteInput').value||'').trim(); if(!v) return; DRAFT.notes.push(v); el('noteInput').value=''; renderNotesList(); scheduleSave(); });
 
       // Toelichting preview + ondertekenen
       function buildNotesPreview(){

--- a/index.html
+++ b/index.html
@@ -57,7 +57,16 @@
         div.className='card';
         const info=document.createElement('div');
         info.className='info';
-        const yearly = d.pricing && d.pricing.yearly ? d.pricing.yearly : 0;
+        let yearly = 0;
+        if(d.pricing){
+          if(typeof d.pricing.yearly==='number' && d.pricing.yearly>0){
+            yearly = d.pricing.yearly;
+          }else if(Array.isArray(d.pricing.posts)){
+            yearly = d.pricing.posts.reduce((sum,p)=> sum + (p.yearly||0) + (p.sp_yearly||0),0);
+          }else if(d.pricing.price && d.pricing.frequency){
+            yearly = (d.pricing.price||0)*(d.pricing.frequency||0);
+          }
+        }
         info.innerHTML=`<strong>${d.meta?.companyName||'Onbekend'}</strong><br>Type: ${d.kind||'-'}<br>Onze referentie: ${d.meta?.ourRef||'-'}<br>Prijs per jaar: € ${(yearly).toLocaleString('nl-NL',{minimumFractionDigits:2, maximumFractionDigits:2})}`;
         div.appendChild(info);
         const edit=document.createElement('button');


### PR DESCRIPTION
## Summary
- ensure pricing posts and notes are saved immediately to localStorage
- compute and persist yearly totals for quotes
- display correct yearly price on the homepage and add a Homepage button to the builder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7e550fa883308059dadced3ef66e